### PR TITLE
Round 2: Fight!

### DIFF
--- a/steam-multiplayer-peer/steam_multiplayer_peer.h
+++ b/steam-multiplayer-peer/steam_multiplayer_peer.h
@@ -6,7 +6,7 @@
 
 // Include Steamworks API headers
 #include "map"
-#include "steam/steam_api.h"
+#include "steam/steam_api_flat.h"
 #include "steam/steamnetworkingfakeip.h"
 #include "steam_connection.h"
 #include "steam_peer_config.h"

--- a/steam-multiplayer-peer/steam_packet_peer.cpp
+++ b/steam-multiplayer-peer/steam_packet_peer.cpp
@@ -3,8 +3,12 @@
 void SteamPacketPeer::_bind_methods() {
 }
 
+void SteamPacketPeer::_bind_methods() {
+}
+
+
 SteamPacketPeer::SteamPacketPeer(const void *p_buffer, uint32_t p_buffer_size, int transferMode) {
-	ERR_FAIL_COND_MSG(p_buffer_size > MAX_STEAM_PACKET_SIZE, "Error: Tried to send a packet larger than MAX_STEAM_PACKET_SIZE");
+	ERR_FAIL_COND_MSG(p_buffer_size > MAX_STEAM_PACKET_SIZE, vformat("Error: Tried to send a packet larger than MAX_STEAM_PACKET_SIZE: %d", p_buffer_size));
 	memcpy(this->data, p_buffer, p_buffer_size);
 	this->size = p_buffer_size;
 	this->transfer_mode = transferMode;

--- a/steam-multiplayer-peer/steam_packet_peer.h
+++ b/steam-multiplayer-peer/steam_packet_peer.h
@@ -1,7 +1,8 @@
 #ifndef STEAM_PACKET_PEER_H
 #define STEAM_PACKET_PEER_H
 
-#include "steam/steam_api.h"
+
+#include "steam/steam_api_flat.h"
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 
@@ -13,15 +14,33 @@ class SteamPacketPeer : public RefCounted {
 	GDCLASS(SteamPacketPeer, RefCounted)
 
 public:
+
+	enum SteamNetworkingSend {
+		SEND_UNRELIABLE = k_nSteamNetworkingSend_Unreliable,
+		SEND_NO_NAGLE = k_nSteamNetworkingSend_NoNagle,
+		SEND_URELIABLE_NO_NAGLE = k_nSteamNetworkingSend_UnreliableNoNagle,
+		SEND_NO_DELAY = k_nSteamNetworkingSend_NoDelay,
+		SEND_UNRELIABLE_NO_DELAY = k_nSteamNetworkingSend_UnreliableNoDelay,
+		SEND_RELIABLE = k_nSteamNetworkingSend_Reliable,
+		SEND_RELIABLE_NO_NAGLE = k_nSteamNetworkingSend_ReliableNoNagle,
+		SEND_USE_CURRENT_THREAD = k_nSteamNetworkingSend_UseCurrentThread,
+		SEND_AUTORESTART_BROKEN_SESSION = k_nSteamNetworkingSend_AutoRestartBrokenSession
+	};
+
 	uint8_t data[MAX_STEAM_PACKET_SIZE];
 	uint32_t size = 0;
 	uint64_t sender;
-	int transfer_mode = k_nSteamNetworkingSend_Reliable; //Looks like a spot that might be served by an enum, eventually.
+	int transfer_mode = SEND_RELIABLE;
 	SteamPacketPeer() {}
 	SteamPacketPeer(const void *p_buffer, uint32_t p_buffer_size, int transferMode);
 
 protected:
 	static void _bind_methods();
 };
+
+protected:
+	static void _bind_methods();
+};
+
 
 #endif // STEAM_PACKET_PEER_H


### PR DESCRIPTION
OK, this fixes the compiling  issue.  Apparently that empty bind_methods is required or else it gets cranky.  This should add in that enum, fix the assignment, and swaps the API for the Flat version.