### PR TITLE
Fix SteamMultiplayerPeer destructor

### DIFF
--- a/steam-multiplayer-peer/steam_multiplayer_peer.cpp
+++ b/steam-multiplayer-peer/steam_multiplayer_peer.cpp
@@ -13,7 +13,7 @@ SteamMultiplayerPeer::SteamMultiplayerPeer() :
 
 SteamMultiplayerPeer::~SteamMultiplayerPeer() {
 	if (_is_active()) {
-		close();
+		_close();
 	}
 	// memdelete(*config);
 }


### PR DESCRIPTION
Solves #19

The problem was most likely a simple typo in the destructor of the SteamMultiplayerPeer class.
Tested in Godot v4.4.1-stable on Windows 11 and Ubuntu 24.04