### PR TITLE
C# Bindings

### DIFF
--- a/steam-multiplayer-peer-csharp-bindings/SteamConnection.cs
+++ b/steam-multiplayer-peer-csharp-bindings/SteamConnection.cs
@@ -1,0 +1,22 @@
+using System;
+using Godot;
+
+namespace SteamMultiplayerPeerCSharp;
+
+public sealed partial class SteamConnection : RefCounted
+{
+    private readonly GodotObject _classReference;
+
+    public SteamConnection()
+    {
+        var name = new StringName(nameof(SteamConnection));
+        
+        if (!ClassDB.ClassExists(name))
+            throw new NotSupportedException($"{name} class doesn't exist");
+            
+        if (!ClassDB.CanInstantiate(name))
+            throw new Exception($"{name} cannot be instantiated");
+            
+        _classReference = ClassDB.Instantiate(name).AsGodotObject();
+    }
+}

--- a/steam-multiplayer-peer-csharp-bindings/SteamEnums.cs
+++ b/steam-multiplayer-peer-csharp-bindings/SteamEnums.cs
@@ -1,0 +1,125 @@
+namespace SteamMultiplayerPeerCSharp;
+
+public enum SteamNetworkingConfig : long
+{
+    // Invalid
+    Invalid = 0, // k_ESteamNetworkingConfig_Invalid
+
+    // Simulating network conditions
+    FakePacketLossSend               = 2,  // k_ESteamNetworkingConfig_FakePacketLoss_Send
+    FakePacketLossRecv               = 3,  // k_ESteamNetworkingConfig_FakePacketLoss_Recv
+    FakePacketLagSend                = 4,  // k_ESteamNetworkingConfig_FakePacketLag_Send
+    FakePacketLagRecv                = 5,  // k_ESteamNetworkingConfig_FakePacketLag_Recv
+    FakePacketReorderSend            = 6,  // k_ESteamNetworkingConfig_FakePacketReorder_Send
+    FakePacketReorderRecv            = 7,  // k_ESteamNetworkingConfig_FakePacketReorder_Recv
+    FakePacketReorderTime            = 8,  // k_ESteamNetworkingConfig_FakePacketReorder_Time
+    FakePacketDupSend                = 26, // k_ESteamNetworkingConfig_FakePacketDup_Send
+    FakePacketDupRecv                = 27, // k_ESteamNetworkingConfig_FakePacketDup_Recv
+    FakePacketDupTimeMax             = 28, // k_ESteamNetworkingConfig_FakePacketDup_TimeMax
+    PacketTraceMaxBytes              = 41, // k_ESteamNetworkingConfig_PacketTraceMaxBytes
+    FakeRateLimitSendRate            = 42, // k_ESteamNetworkingConfig_FakeRateLimit_Send_Rate
+    FakeRateLimitSendBurst           = 43, // k_ESteamNetworkingConfig_FakeRateLimit_Send_Burst
+    FakeRateLimitRecvRate            = 44, // k_ESteamNetworkingConfig_FakeRateLimit_Recv_Rate
+    FakeRateLimitRecvBurst           = 45, // k_ESteamNetworkingConfig_FakeRateLimit_Recv_Burst
+    OutOfOrderCorrectionWindowMicroseconds = 51, // k_ESteamNetworkingConfig_OutOfOrderCorrectionWindowMicroseconds
+
+    // Connection options
+    ConnectionUserData               = 40, // k_ESteamNetworkingConfig_ConnectionUserData
+    TimeoutInitial                   = 24, // k_ESteamNetworkingConfig_TimeoutInitial
+    TimeoutConnected                 = 25, // k_ESteamNetworkingConfig_TimeoutConnected
+    SendBufferSize                   = 9,  // k_ESteamNetworkingConfig_SendBufferSize
+    RecvBufferSize                   = 47, // k_ESteamNetworkingConfig_RecvBufferSize
+    RecvBufferMessages               = 48, // k_ESteamNetworkingConfig_RecvBufferMessages
+    RecvMaxMessageSize               = 49, // k_ESteamNetworkingConfig_RecvMaxMessageSize
+    RecvMaxSegmentsPerPacket         = 50, // k_ESteamNetworkingConfig_RecvMaxSegmentsPerPacket
+    SendRateMin                      = 10, // k_ESteamNetworkingConfig_SendRateMin
+    SendRateMax                      = 11, // k_ESteamNetworkingConfig_SendRateMax
+    NagleTime                        = 12, // k_ESteamNetworkingConfig_NagleTime
+    IPAllowWithoutAuth               = 23, // k_ESteamNetworkingConfig_IP_AllowWithoutAuth
+    IPLocalHostAllowWithoutAuth      = 52, // k_ESteamNetworkingConfig_IPLocalHost_AllowWithoutAuth
+    MTUPacketSize                    = 32, // k_ESteamNetworkingConfig_MTU_PacketSize
+    MTUDataSize                      = 33, // k_ESteamNetworkingConfig_MTU_DataSize
+    Unencrypted                      = 34, // k_ESteamNetworkingConfig_Unencrypted
+    SymmetricConnect                 = 37, // k_ESteamNetworkingConfig_SymmetricConnect
+    LocalVirtualPort                 = 38, // k_ESteamNetworkingConfig_LocalVirtualPort
+    DualWifiEnable                   = 39, // k_ESteamNetworkingConfig_DualWifi_Enable
+    EnableDiagnosticsUI              = 46, // k_ESteamNetworkingConfig_EnableDiagnosticsUI
+
+    // SDR settings
+    SDRClientConsecutivePingTimeoutsFailInitial = 19, // k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFailInitial
+    SDRClientConsecutivePingTimeoutsFail        = 20, // k_ESteamNetworkingConfig_SDRClient_ConsecutitivePingTimeoutsFail
+    SDRClientMinPingsBeforePingAccurate         = 21, // k_ESteamNetworkingConfig_SDRClient_MinPingsBeforePingAccurate
+    SDRClientSingleSocket                       = 22, // k_ESteamNetworkingConfig_SDRClient_SingleSocket
+    SDRClientForceRelayCluster                  = 29, // k_ESteamNetworkingConfig_SDRClient_ForceRelayCluster
+    SDRClientDevTicket                          = 30, // k_ESteamNetworkingConfig_SDRClient_DevTicket
+    SDRClientForceProxyAddr                     = 31, // k_ESteamNetworkingConfig_SDRClient_ForceProxyAddr
+    SDRClientFakeClusterPing                    = 36, // k_ESteamNetworkingConfig_SDRClient_FakeClusterPing
+    SDRClientLimitPingProbesToNearestN          = 60, // k_ESteamNetworkingConfig_SDRClient_LimitPingProbesToNearestN
+
+    // Log levels
+    LogLevelAckRTT           = 13, // k_ESteamNetworkingConfig_LogLevel_AckRTT
+    LogLevelPacketDecode     = 14, // k_ESteamNetworkingConfig_LogLevel_PacketDecode
+    LogLevelMessage          = 15, // k_ESteamNetworkingConfig_LogLevel_Message
+    LogLevelPacketGaps       = 16, // k_ESteamNetworkingConfig_LogLevel_PacketGaps
+    LogLevelP2PRendezvous    = 17, // k_ESteamNetworkingConfig_LogLevel_P2PRendezvous
+    LogLevelSDRRelayPings    = 18, // k_ESteamNetworkingConfig_LogLevel_SDRRelayPings
+
+    // Callbacks
+    CallbackConnectionStatusChanged = 201, // k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged
+    CallbackAuthStatusChanged       = 202, // k_ESteamNetworkingConfig_Callback_AuthStatusChanged
+    CallbackRelayNetworkStatusChanged = 203, // k_ESteamNetworkingConfig_Callback_RelayNetworkStatusChanged
+    CallbackMessageSessionRequest   = 204, // k_ESteamNetworkingConfig_Callback_MessagesSessionRequest
+    CallbackMessagesSessionFailed   = 205, // k_ESteamNetworkingConfig_Callback_MessagesSessionFailed
+    CallbackCreateConnectionSignaling = 206, // k_ESteamNetworkingConfig_Callback_CreateConnectionSignaling
+    CallbackFakeIPResult            = 207, // k_ESteamNetworkingConfig_Callback_FakeIPResult
+
+    // P2P settings
+    P2PStunServerList          = 103, // k_ESteamNetworkingConfig_P2P_STUN_ServerList
+    P2PTransportIceEnable      = 104, // k_ESteamNetworkingConfig_P2P_Transport_ICE_Enable
+    P2PTransportIcePenalty     = 105, // k_ESteamNetworkingConfig_P2P_Transport_ICE_Penalty
+    P2PTransportSdrPenalty     = 106, // k_ESteamNetworkingConfig_P2P_Transport_SDR_Penalty
+    P2PTurnServerList          = 107, // k_ESteamNetworkingConfig_P2P_TURN_ServerList
+    P2PTurnUserList            = 108, // k_ESteamNetworkingConfig_P2P_TURN_UserList
+    P2PTurnPassList            = 109, // k_ESteamNetworkingConfig_P2P_TURN_PassList
+    P2PTransportIceImplementation = 110, // k_ESteamNetworkingConfig_P2P_Transport_ICE_Implementation
+
+    // Experimental / other
+    ECN            = 999,          // k_ESteamNetworkingConfig_ECN
+    Force32Bit     = 0x7fffffff,  // k_ESteamNetworkingConfig_Value_Force32Bit
+}
+
+public enum SocketConnectionType : long
+{
+    NotConnected = 0, // k_ESNetSocketConnectionTypeNotConnected
+    UDP          = 1, // k_ESNetSocketConnectionTypeUDP
+    UDPRelay     = 2, // k_ESNetSocketConnectionTypeUDPRelay
+}
+
+public enum SocketState : long
+{
+    Invalid                  = 0,  // k_ESNetSocketStateInvalid
+    Connected                = 1,  // k_ESNetSocketStateConnected
+    Initiated                = 10, // k_ESNetSocketStateInitiated
+    LocalCandidatesFound     = 11, // k_ESNetSocketStateLocalCandidatesFound
+    ReceivedRemoteCandidates = 12, // k_ESNetSocketStateReceivedRemoteCandidates
+    ChallengeHandshake       = 15, // k_ESNetSocketStateChallengeHandshake
+    Disconnecting            = 21, // k_ESNetSocketStateDisconnecting
+    LocalDisconnect          = 22, // k_ESNetSocketStateLocalDisconnect
+    TimeoutDuringConnect     = 23, // k_ESNetSocketStateTimeoutDuringConnect
+    RemoteEndDisconnected    = 24, // k_ESNetSocketStateRemoteEndDisconnected
+    ConnectionBroken         = 25, // k_ESNetSocketStateConnectionBroken
+}
+
+public enum NetworkingConnectionState : long
+{
+    None                   = 0, // k_ESteamNetworkingConnectionState_None
+    Connecting             = 1, // k_ESteamNetworkingConnectionState_Connecting
+    FindingRoute           = 2, // k_ESteamNetworkingConnectionState_FindingRoute
+    Connected              = 3, // k_ESteamNetworkingConnectionState_Connected
+    ClosedByPeer           = 4, // k_ESteamNetworkingConnectionState_ClosedByPeer
+    ProblemDetectedLocally = 5, // k_ESteamNetworkingConnectionState_ProblemDetectedLocally
+    FinWait                = -1, // k_ESteamNetworkingConnectionState_FinWait
+    Linger                 = -2, // k_ESteamNetworkingConnectionState_Linger
+    Dead                   = -3, // k_ESteamNetworkingConnectionState_Dead
+    Force32Bit             = 0x7fffffff,
+}

--- a/steam-multiplayer-peer-csharp-bindings/SteamMultiplayerPeer.cs
+++ b/steam-multiplayer-peer-csharp-bindings/SteamMultiplayerPeer.cs
@@ -1,0 +1,105 @@
+using System;
+using Godot;
+using Dictionary = Godot.Collections.Dictionary;
+
+namespace SteamMultiplayerPeerCSharp;
+
+public sealed partial class SteamMultiplayerPeer : RefCounted
+{
+    public MultiplayerPeerExtension MultiplayerPeer => (MultiplayerPeerExtension)_classReference;
+
+    public delegate void NetworkConnectionStatusChangedEventHandler(long connect_handle, Dictionary connection, long old_state);
+
+    public event NetworkConnectionStatusChangedEventHandler NetworkConnectionStatusChanged;
+
+    public int ListenSocket
+    {
+        get => _classReference.Call(Methods.GetListenSocket).As<int>();
+        set => _classReference.Call(Methods.SetListenSocket, value);
+    }
+
+    public bool NoNagle
+    {
+        get => _classReference.Call(Methods.GetNoNagle).As<bool>();
+        set => _classReference.Call(Methods.SetNoNagle, value);
+    }
+
+    public bool NoDelay
+    {
+        get => _classReference.Call(Methods.GetNoDelay).As<bool>();
+        set => _classReference.Call(Methods.SetNoDelay, value);
+    }
+
+    public SteamPeerConfig Configs
+    {
+        get => GetConfigs();
+        set => SetConfigs(value);
+    }
+
+    private readonly GodotObject _classReference;
+    private readonly Callable _signalTrampoline;
+    private bool _disposed;
+
+    public SteamMultiplayerPeer()
+    {
+        var sn = new StringName(nameof(SteamMultiplayerPeer));
+        if (!ClassDB.ClassExists(sn)) throw new NotSupportedException($"{sn} class doesn't exist");
+        if (!ClassDB.CanInstantiate(sn)) throw new Exception($"{sn} cannot be instantiated");
+
+        _classReference = ClassDB.Instantiate(sn).AsGodotObject();
+
+        _signalTrampoline = Callable.From(
+            (long h, Dictionary d, long o) => NetworkConnectionStatusChanged?.Invoke(h, d, o));
+        _classReference.Connect(Signals.NetworkConnectionStatusChanged, _signalTrampoline);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (_classReference.IsConnected(Signals.NetworkConnectionStatusChanged, _signalTrampoline))
+            _classReference.Disconnect(Signals.NetworkConnectionStatusChanged, _signalTrampoline);
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public Error CreateHost(ushort port) => _classReference.Call(Methods.CreateHost, port).As<Error>();
+    public Error CreateClient(ulong steamId, ushort port) => _classReference.Call(Methods.CreateClient, steamId, port).As<Error>();
+    public ulong GetSteam64FromPeerId(int peerId) => _classReference.Call(Methods.GetSteam64FromPeerId, peerId).As<ulong>();
+    public int GetPeerIdFromSteam64(ulong steamId) => _classReference.Call(Methods.GetPeerIdFromSteam64, steamId).As<int>();
+    public bool CloseListenSocket() => _classReference.Call(Methods.CloseListenSocket).As<bool>();
+    public void SetListenSocket(int s) => _classReference.Call(Methods.SetListenSocket, s);
+    public int GetListenSocket() => _classReference.Call(Methods.GetListenSocket).As<int>();
+    public void SetNoNagle(bool e) => _classReference.Call(Methods.SetNoNagle, e);
+    public bool GetNoNagle() => _classReference.Call(Methods.GetNoNagle).As<bool>();
+    public void SetNoDelay(bool e) => _classReference.Call(Methods.SetNoDelay, e);
+    public bool GetNoDelay() => _classReference.Call(Methods.GetNoDelay).As<bool>();
+    public Dictionary GetPeerMap() => _classReference.Call(Methods.GetPeerMap).As<Dictionary>();
+    public void SetConfigs(SteamPeerConfig c) => _classReference.Call(Methods.SetConfigs, c?.ClassReference);
+    public SteamPeerConfig GetConfigs() => Configs;
+    public void SetConfig(SteamNetworkingConfig c, Variant v) => Configs.SetConfig(c, v);
+    public void ClearConfig(SteamNetworkingConfig c) => Configs.ClearConfig(c);
+    public void ClearAllConfigs() => Configs.ClearAllConfigs();
+
+    private static class Methods
+    {
+        public static readonly StringName CreateHost = new("create_host");
+        public static readonly StringName CreateClient = new("create_client");
+        public static readonly StringName GetSteam64FromPeerId = new("get_steam64_from_peer_id");
+        public static readonly StringName GetPeerIdFromSteam64 = new("get_peer_id_from_steam64");
+        public static readonly StringName CloseListenSocket = new("close_listen_socket");
+        public static readonly StringName SetListenSocket = new("set_listen_socket");
+        public static readonly StringName GetListenSocket = new("get_listen_socket");
+        public static readonly StringName SetNoNagle = new("set_no_nagle");
+        public static readonly StringName GetNoNagle = new("get_no_nagle");
+        public static readonly StringName SetNoDelay = new("set_no_delay");
+        public static readonly StringName GetNoDelay = new("get_no_delay");
+        public static readonly StringName GetPeerMap = new("get_peer_map");
+        public static readonly StringName SetConfigs = new("set_configs");
+        public static readonly StringName GetConfigs = new("get_configs");
+    }
+
+    private static class Signals
+    {
+        public static readonly StringName NetworkConnectionStatusChanged = new("network_connection_status_changed");
+    }
+}

--- a/steam-multiplayer-peer-csharp-bindings/SteamPacketPeer.cs
+++ b/steam-multiplayer-peer-csharp-bindings/SteamPacketPeer.cs
@@ -1,0 +1,20 @@
+using System;
+using Godot;
+
+public sealed partial class SteamPacketPeer : RefCounted
+{
+    private readonly GodotObject _classReference;
+
+    public SteamPacketPeer()
+    {
+        var name = new StringName(nameof(SteamPacketPeer));
+        
+        if (!ClassDB.ClassExists(name))
+            throw new NotSupportedException($"{name} class doesn't exist");
+            
+        if (!ClassDB.CanInstantiate(name))
+            throw new Exception($"{name} cannot be instantiated");
+
+        _classReference = ClassDB.Instantiate(name).AsGodotObject();
+    }
+}

--- a/steam-multiplayer-peer-csharp-bindings/SteamPeerConfig.cs
+++ b/steam-multiplayer-peer-csharp-bindings/SteamPeerConfig.cs
@@ -1,0 +1,59 @@
+using System;
+using Godot;
+using Dictionary = Godot.Collections.Dictionary;
+
+namespace SteamMultiplayerPeerCSharp;
+
+public sealed partial class SteamPeerConfig : RefCounted
+{
+    public GodotObject ClassReference => _classReference;
+
+    private readonly GodotObject _classReference;
+
+    public SteamPeerConfig()
+    {
+        var stringName = new StringName(nameof(SteamPeerConfig));
+
+        if (!ClassDB.ClassExists(stringName))
+            throw new NotSupportedException($"{stringName} class doesn't exist");
+
+        if (!ClassDB.CanInstantiate(stringName))
+            throw new Exception($"{stringName} cannot be instantiated.");
+
+        _classReference = ClassDB.Instantiate(stringName).AsGodotObject();
+    }
+    public SteamPeerConfig(GodotObject classReference)
+    {
+        _classReference = classReference ?? throw new ArgumentNullException(nameof(classReference));
+    }
+
+    public Dictionary Options
+    {
+        get => GetOptions();
+        set => SetOptions(value);
+    }
+
+    public Dictionary GetOptions()
+        => _classReference.Call(Methods.GetOptions).As<Dictionary>();
+
+    public void SetOptions(Dictionary options)
+        => _classReference.Call(Methods.SetOptions, options);
+
+    public void SetConfig(SteamNetworkingConfig config, Variant value) =>
+        _classReference.Call(Methods.SetConfig, (long)config, value);
+
+    public void ClearConfig(SteamNetworkingConfig config) =>
+        _classReference.Call(Methods.ClearConfig, (long)config);
+
+    public void ClearAllConfigs() =>
+        _classReference.Call(Methods.ClearAllConfigs);
+
+    private static class Methods
+    {
+        public static readonly StringName GetOptions = new("get_options");
+        public static readonly StringName SetOptions = new("set_options");
+        public static readonly StringName SetConfig = new("set_config");
+        public static readonly StringName ClearConfig = new("clear_config");
+        public static readonly StringName ClearAllConfigs = new("clear_all_configs");
+    }
+}


### PR DESCRIPTION
We are currently working on a project using the following setup:

- **Godot 4.4.1 Mono**
- **[GodotSteam](https://github.com/GodotSteam/GodotSteam)**
- **[[GodotSteam_CSharpBindings 1.1.0](https://github.com/LauraWebdev/GodotSteam_CSharpBindings)**  
  *(Note: We made some modifications; see LauraWebdev/GodotSteam_CSharpBindings/issues/43*
- **steam-multiplayer-peer 0.2.4**

While integrating Steam multiplayer support, we encountered several challenges, particularly related to C# interoperability with Godot’s networking system.

We found a pull request that added C# support by directly inheriting from `MultiplayerPeerExtension` (#21). However, this approach led to several issues:

- Internally, Godot calls `_get_packet` and `_put_packet`.
- In C#, we can only override methods explicitly defined in `MultiplayerPeerExtension`.
- As a fallback, the engine attempts to call `_get_packet_script` and `_put_packet_script`.
- On the C++ side, these fallback methods were commented out and not implemented. Attempting to call them from C# resulted in runtime errors, as discussed in #22

To address this, we implemented `_get_packet_script` and `_put_packet_script` in C++. However, we did not manually bind these methods, since they are already registered as virtual functions in the base class; manually binding them would have caused a "double bind" error.

Even after this workaround, we continued facing problems — mainly C# being unaware of what to execute, and certain methods being occluded by the C++ internals.

Due to these ongoing issues, we changed our approach:

Instead of inheriting from `MultiplayerPeerExtension`, we built a **literal wrapper class**.  
This wrapper facilitates communication between the C# layer and the underlying GDScript/C++ implementations, without attempting to fully extend `MultiplayerPeerExtension`.

Additionally, we introduced some Enums for SteamConfigs, ConnectionStatus, etc.

It is also important to note that we encountered an issue where the client would disconnect after a certain period of time. On the client side, we were receiving a k_EResultInvalidParam error, which, according to the Steamworks documentation, indicates:

k_EResultInvalidParam: Invalid connection handle, or the individual message is too big.
(See k_cbMaxSteamNetworkingSocketsMessageSizeSend.)

After further investigation, we confirmed that the problem was related to the connection itself. We added validation checks before sending any data to ensure the connection was still valid.

Digging deeper, we discovered that Godot was somehow discarding the NativeInstance associated with the connection. It appeared that Godot was not recognizing that C# still held a reference to the object (or to the MultiplayerAPI instance itself).

Our current workaround was to subscribe directly to events inside the constructor, creating a dependency that Godot seems to respect and retain properly.
This prevented the premature discarding of the NativeInstance and stabilized the connection.

We are still looking for answers, hopefully somebody also has a lead on this.

To use this, just put the folder with the .cs inside the addons folder, next to the steam-multiplayer-peer addon. 
You must reference the public `MultiplayerPeer` property and maintain a strong reference to the `SteamMultiplayerPeer` instance to easily execute methods and connect to signals.